### PR TITLE
Modify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IOTA=iota$(IOTA_VER)
 
 all: $(IOTA).tex
 	pdflatex $^
+	pdflatex $^
 
 clean:
 	$(RM) $(IOTA).pdf $(IOTA).aux $(IOTA).log


### PR DESCRIPTION
Because of cross-reference, pdflatex needs to be exucuted twice.